### PR TITLE
Adding new linting rules

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -75,5 +75,6 @@ module.exports = {
         "@babel/no-invalid-this": "error",
 
         "no-multiple-empty-lines": ["error", { "max": 1 }],
+        "object-curly-spacing": ["error", "always"]
     },
 }

--- a/javascript.js
+++ b/javascript.js
@@ -73,5 +73,7 @@ module.exports = {
         "no-invalid-this": "off",
         // ...so we replace it with a version that is class property aware
         "@babel/no-invalid-this": "error",
+
+        "no-multiple-empty-lines": ["error", { "max": 1 }],
     },
 }


### PR DESCRIPTION
Those have come up in a couple of my PR and it seems pretty sensible to update our default to ensure consistent styling

- [no-multiple-empty-lines](https://eslint.org/docs/rules/no-multiple-empty-lines)
- [object-curly-spacing](https://eslint.org/docs/rules/object-curly-spacing)

Fixes vector-im/element-web#17236
Fixes vector-im/element-web#17232 

# Transition progress

| Layer name | Pull request | Status |
| ---------- | ------------ | ------ |
| matrix-js-sdk | matrix-org/matrix-js-sdk#1688 | ✅ |
| matrix-react-sdk | Waiting to use `eslint-plugin-matrix-org` | - |
| element-web | Waiting to use `eslint-plugin-matrix-org` | - |
| element-desktop | Waiting to use `eslint-plugin-matrix-org` | - |

