### PR TITLE
Extract a separate Babel layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 projects. It codifies
 https://github.com/matrix-org/matrix-react-sdk/blob/develop/code_style.md.
 
-This package contains several ESLint configs:
+This package contains several main ESLint configs for different project styles:
 
-- `matrix-org/javascript`: The style for JavaScript projects.
-- `matrix-org/react`: The style for React projects. Intended to be used in
-  conjunction with `matrix-org/javascript` or `matrix-org/typescript`.
+- `matrix-org/javascript`: The style for native JavaScript projects.
+- `matrix-org/babel`: The style for Babel JavaScript projects. It extends
+  `matrix-org/javascript`.
 - `matrix-org/typescript`: The style for TypeScript projects. It extends
   `matrix-org/javascript`.
+
+There is also a mixin config that can be used together with any of the above:
+
+- `matrix-org/react`: The style for React projects.
 
 # Getting started
 
@@ -22,7 +26,7 @@ yarn add eslint-plugin-matrix-org --dev
 
 You can then add any of the following to your ESLint config:
 
-Standard JavaScript style
+Standard native JavaScript
 ```js
 {
     plugins: [
@@ -34,7 +38,19 @@ Standard JavaScript style
 }
 ```
 
-Standard TypeScript style
+Standard Babel JavaScript
+```js
+{
+    plugins: [
+        "matrix-org",
+    ],
+    extends: [
+        "plugin:matrix-org/babel",
+    ]
+}
+```
+
+Standard TypeScript
 ```js
 {
     plugins: [
@@ -46,7 +62,7 @@ Standard TypeScript style
 }
 ```
 
-Standard JavaScript with React
+Standard native JavaScript with React
 ```js
 {
     plugins: [
@@ -54,6 +70,19 @@ Standard JavaScript with React
     ],
     extends: [
         "plugin:matrix-org/javascript",
+        "plugin:matrix-org/react",
+    ]
+}
+```
+
+Standard Babel JavaScript with React
+```js
+{
+    plugins: [
+        "matrix-org",
+    ],
+    extends: [
+        "plugin:matrix-org/babel",
         "plugin:matrix-org/react",
     ]
 }

--- a/babel.js
+++ b/babel.js
@@ -1,0 +1,25 @@
+module.exports = {
+    plugins: [
+        "@babel",
+        "matrix-org",
+    ],
+    extends: [
+        "plugin:matrix-org/javascript",
+    ],
+
+    parser: "@babel/eslint-parser", // Needed for class properties
+    parserOptions: {
+        sourceType: "module",
+    },
+    env: {
+        // We expect all projects to use ES6 or newer
+        es6: true,
+        jest: true,
+    },
+    rules: {
+        // ESLint's built in `no-invalid-this` rule breaks with class properties
+        "no-invalid-this": "off",
+        // ...so we replace it with a version that is class property aware
+        "@babel/no-invalid-this": "error",
+    },
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     configs: {
+        "babel": require("./babel"),
         "javascript": require("./javascript"),
         "react": require("./react"),
         "typescript": require("./typescript"),

--- a/javascript.js
+++ b/javascript.js
@@ -1,36 +1,24 @@
 module.exports = {
-    plugins: [
-        "@babel",
-    ],
     extends: [
         "eslint:recommended",
         "google",
     ],
-    parser: "@babel/eslint-parser", // Needed for class properties
-    parserOptions: {
-        sourceType: "module",
-    },
-    env: {
-        // We expect all projects to use ES6 or newer
-        es6: true,
-        jest: true,
-    },
     rules: {
         // Additional rules we adhere to
         "indent": [
-          "error",
-          4,
-          {
-            SwitchCase: 1,
-            ArrayExpression: "off",
-            ObjectExpression: "off",
-          },
+            "error",
+            4,
+            {
+                SwitchCase: 1,
+                ArrayExpression: "off",
+                ObjectExpression: "off",
+            },
         ],
         "max-len": ["error", {
             code: 120,
             ignoreComments: true,
         }],
-        curly: ["error", "multi-line"],
+        "curly": ["error", "multi-line"],
         "prefer-const": ["error"],
         "comma-dangle": ["error", {
             arrays: "always-multiline",
@@ -68,11 +56,6 @@ module.exports = {
         "operator-linebreak": ["off"],
         // We don't mind strange alignments in EOL comments
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
-
-        // ESLint's built in `no-invalid-this` rule breaks with class properties
-        "no-invalid-this": "off",
-        // ...so we replace it with a version that is class property aware
-        "@babel/no-invalid-this": "error",
 
         "no-multiple-empty-lines": ["error", { "max": 1 }],
         "object-curly-spacing": ["error", "always"]


### PR DESCRIPTION
Some projects (like `element-desktop`) use native JavaScript without Babel, so they don't want to pull in a Babel parser just to lint. This separates native JS and Babel JS configs to offer both options.

Used by https://github.com/vector-im/element-desktop/pull/197