### PR TITLE
Add missing @typescript-eslint/semi rule

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -28,6 +28,7 @@ module.exports = {
         // `typescript-eslint` has a rule for semis which conflicts with the
         // original ESLint core rule.
         "semi": ["off"],
+        "@typescript-eslint/semi": ["error"],
 
         // We're relying on TS types and going with more ad hoc JS docs
         "valid-jsdoc": ["off"],


### PR DESCRIPTION
We seem to have missed enabling @typescript-eslint/semi, so we just weren't checking at all in TS files.