### PR TITLE
Add member-delimiter-style rule

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -30,6 +30,18 @@ module.exports = {
         "semi": ["off"],
         "@typescript-eslint/semi": ["error"],
 
+        // Similarly, enforce semicolons between members (ie. in types / interfaces)
+        "@typescript-eslint/member-delimiter-style": ["error", {
+            "multiline": {
+                "delimiter": "semi",
+                "requireLast": true,
+            },
+            "singleline": {
+                "delimiter": "comma",
+                "requireLast": false,
+            },
+        }],
+
         // We're relying on TS types and going with more ad hoc JS docs
         "valid-jsdoc": ["off"],
 


### PR DESCRIPTION
Because I keep getting it wrong and it gets picked up in code review

We probably don't want to merge this until we've made at least element-web/react-sdk/js-sdk/desktop/builder actually obey it