### PR TITLE
Improve react lint rules

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -48,7 +48,6 @@ module.exports = {
         "no-prototype-builtins": ["off"],
 
         // Rules we do not want from the Google style guide
-        "object-curly-spacing": ["off"],
         "spaced-comment": ["off"],
         "guard-for-in": ["off"],
         "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
@@ -58,6 +57,6 @@ module.exports = {
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
 
         "no-multiple-empty-lines": ["error", { "max": 1 }],
-        "object-curly-spacing": ["error", "always"]
+        "object-curly-spacing": ["error", "always"],
     },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-matrix-org",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "ESLint rules and configs used by Matrix.org projects",
     "keywords": [
         "eslint"

--- a/react.js
+++ b/react.js
@@ -30,7 +30,9 @@ module.exports = {
         // or after the closing slash, and no spacing after the opening
         // bracket of the opening tag or closing tag.
         // https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/jsx-tag-spacing.md
-        "react/jsx-tag-spacing": ["error"],
+        "react/jsx-tag-spacing": ["error", {
+            beforeClosing: "never",
+        }],
 
         "react/jsx-curly-spacing": ["error", {
             allowMultiline: true,
@@ -41,6 +43,11 @@ module.exports = {
         "react/jsx-curly-brace-presence": ["error", "never"],
 
         "react/jsx-equals-spacing": ["error", "never"],
+
+        "react/no-direct-mutation-state": ["error"],
+        "react/no-this-in-sfc": ["error"],
+        "react/self-closing-comp": ["error"],
+        "react/jsx-max-props-per-line": ["error", {"when": "multiline"}],
 
         "react-hooks/rules-of-hooks": ["error"],
         "react-hooks/exhaustive-deps": ["error"],


### PR DESCRIPTION
Prevents spurious new spaces in jsx tags e.g `<foo bar={123} >`
Also encourages multi-lining props when they do not fit in one line, we had some instances of chunking per line which was wholly unreadable and avoided.