### PR TITLE
Use typescript's own version of indent for typescript rules

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -10,6 +10,16 @@ module.exports = {
     ],
     parser: "@typescript-eslint/parser",
     rules: {
+        "indent": ["off"],
+        "@typescript-eslint/indent": [
+            "error",
+            4,
+            {
+                SwitchCase: 1,
+                ArrayExpression: "off",
+                ObjectExpression: "off",
+            },
+        ],
         // Allow the use of underscore to show args are not used.
         // This is helpful for seeing that a function implements
         // an interface but won't be using one of it's arguments.


### PR DESCRIPTION
Apparently not doing so leads to eslint erroring on 'const' by itself
on a line, which means you get an error popup in vscode every time
you type 'const', which is not exactly ideal.

See https://github.com/typescript-eslint/typescript-eslint/issues/792