### PR TITLE
Revert #13 (Use typescript's own version of indent for typescript rules)

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -10,14 +10,6 @@ module.exports = {
     ],
     parser: "@typescript-eslint/parser",
     rules: {
-        "indent": ["off"],
-        "@typescript-eslint/indent": [
-            "error",
-            4,
-            {
-                SwitchCase: 1,
-            },
-        ],
         // Allow the use of underscore to show args are not used.
         // This is helpful for seeing that a function implements
         // an interface but won't be using one of it's arguments.


### PR DESCRIPTION
It turns out that https://github.com/typescript-eslint/typescript-eslint/issues/1824
is a thing a that this rule basically just doesn't work, and I not only failed to
read that it doesn't work but also failed to test that worked, and it caused a
bunch of silly indenting changes in our code.