### PR TITLE
Require copyright header rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ Standard TypeScript with React and jsx a11y
 }
 ```
 
+To automate adding a copyright header:
+```js
+{
+    plugins: [
+        "matrix-org",
+    ],
+    rules: [
+        "matrix-org/require-copyright-header": ["error", HEADER_TEMPLATE]
+    ]
+}
+```
+The current year can be inserted into the template with the placeholder `%%CURRENT_YEAR%%`
+
+
 This package does not hold any dependencies itself, as it causes conflicts the
 versions of the same dependencies downstream and also would imply installing the
 union of all tools. You should expect that you may need to add some of the

--- a/README.md
+++ b/README.md
@@ -115,18 +115,20 @@ Standard TypeScript with React and jsx a11y
 }
 ```
 
-To automate adding a copyright header:
+To require a copyright header:
 ```js
 {
     plugins: [
         "matrix-org",
     ],
     rules: [
+        "matrix-org/require-copyright-header": "error",
+        // provide a header template as a string to insert on --fix
+        // the current year can be inserted into the template with the placeholder `%%CURRENT_YEAR%%`
         "matrix-org/require-copyright-header": ["error", HEADER_TEMPLATE]
     ]
 }
 ```
-The current year can be inserted into the template with the placeholder `%%CURRENT_YEAR%%`
 
 
 This package does not hold any dependencies itself, as it causes conflicts the

--- a/copyright.js
+++ b/copyright.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        "include-copyright-header": "error"
+    },
+};

--- a/copyright.js
+++ b/copyright.js
@@ -1,5 +1,5 @@
 module.exports = {
     rules: {
-        "include-copyright-header": "error"
+        "matrix-org/include-copyright-header": "error",
     },
 };

--- a/copyright.js
+++ b/copyright.js
@@ -1,5 +1,0 @@
-module.exports = {
-    rules: {
-        "matrix-org/include-copyright-header": "error",
-    },
-};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 module.exports = {
+    rules: {
+        "include-copyright-header": require("./rules/copyright")
+    },
     configs: {
         "babel": require("./babel"),
+        "copyright": require("./copyright"),
         "javascript": require("./javascript"),
         "react": require("./react"),
         "typescript": require("./typescript"),

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 module.exports = {
     rules: {
-        "include-copyright-header": require("./rules/copyright")
+        "require-copyright-header": require("./rules/copyright")
     },
     configs: {
         "babel": require("./babel"),
-        "copyright": require("./copyright"),
         "javascript": require("./javascript"),
         "react": require("./react"),
         "typescript": require("./typescript"),

--- a/rules/copyright.js
+++ b/rules/copyright.js
@@ -1,41 +1,34 @@
-const COPYRIGHT_HEADER = `
-/*
-Copyright %%CURRENT_YEAR%% The Matrix.org Foundation C.I.C.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-`
 module.exports = {
     meta: {
-        fixable: true,
+        fixable: "code",
+        schema: [
+            { type: "string" }
+        ]
     },
     create: function (context) {
         const code = context.getSourceCode();
         return {
             Program(node) {
-                const firstStatement = node.body[0];
+                const firstToken = code.getFirstToken(node, { includeComments: false });
 
-                const [firstComment] = code.getCommentsBefore(firstStatement || node);
-                if (!firstStatement || firstComment?.value?.includes('Copyright')) {
+                if (!firstToken) {
                     return;
                 }
+
+                const headComments = code.getCommentsBefore(firstToken || node);
+                const hasSomeCopyrightHeader = headComments?.some(comment => comment?.value?.includes('Copyright'));
+                if (hasSomeCopyrightHeader) {
+                    return;
+                }
+                const headerTemplate = context.options[0];
+                const fix = headerTemplate ? function (fixer) {
+                    return fixer.insertTextBefore(firstToken, headerTemplate.replace(/%%CURRENT_YEAR%%/g, new Date().getFullYear()))
+                } : undefined;
+
                 context.report({
                     node,
                     message: 'Copyright heading is required',
-                    fix: function (fixer) {
-                        return fixer.insertTextBefore(firstStatement, COPYRIGHT_HEADER.replace(/%%CURRENT_YEAR%%/g, new Date().getFullYear()))
-                    }
+                    fix
                 });
             },
         };

--- a/rules/copyright.js
+++ b/rules/copyright.js
@@ -1,4 +1,25 @@
+const COPYRIGHT_HEADER = `
+/*
+Copyright %%CURRENT_YEAR%% The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+`
 module.exports = {
+    meta: {
+        fixable: true,
+    },
     create: function (context) {
         const code = context.getSourceCode();
         return {
@@ -6,11 +27,18 @@ module.exports = {
                 const firstStatement = node.body[0];
 
                 const [firstComment] = code.getCommentsBefore(firstStatement || node);
-                if (firstComment?.value?.includes('Copyright')) {
+                if (!firstStatement || firstComment?.value?.includes('Copyright')) {
                     return;
                 }
-                context.report(node, 'Copyright heading is required');
+                context.report({
+                    node,
+                    message: 'Copyright heading is required',
+                    fix: function (fixer) {
+                        return fixer.insertTextBefore(firstStatement, COPYRIGHT_HEADER.replace(/%%CURRENT_YEAR%%/g, new Date().getFullYear()))
+                    }
+                });
             },
         };
-    }
+    },
+
 }

--- a/rules/copyright.js
+++ b/rules/copyright.js
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 module.exports = {
     meta: {
         fixable: "code",

--- a/rules/copyright.js
+++ b/rules/copyright.js
@@ -1,0 +1,16 @@
+module.exports = {
+    create: function (context) {
+        const code = context.getSourceCode();
+        return {
+            Program(node) {
+                const firstStatement = node.body[0];
+
+                const [firstComment] = code.getCommentsBefore(firstStatement || node);
+                if (firstComment?.value?.includes('Copyright')) {
+                    return;
+                }
+                context.report(node, 'Copyright heading is required');
+            },
+        };
+    }
+}

--- a/rules/copyright.js
+++ b/rules/copyright.js
@@ -15,7 +15,7 @@ module.exports = {
                     return;
                 }
 
-                const headComments = code.getCommentsBefore(firstToken || node);
+                const headComments = code.getCommentsBefore(firstToken);
                 const hasSomeCopyrightHeader = headComments?.some(comment => comment?.value?.includes('Copyright'));
                 if (hasSomeCopyrightHeader) {
                     return;

--- a/rules/copyright.js
+++ b/rules/copyright.js
@@ -33,5 +33,4 @@ module.exports = {
             },
         };
     },
-
 }


### PR DESCRIPTION
Adds a rule that checks the comments in the head of a file for a copyright header, and can insert one if missing.