### PR TITLE
Allow unused vars when destructuring arrays or objects

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -13,11 +13,7 @@ module.exports = {
         // Allow the use of underscore to show args are not used.
         // This is helpful for seeing that a function implements
         // an interface but won't be using one of it's arguments.
-        "@typescript-eslint/no-unused-vars": ["error", {
-            "args": "none",
-            "destructuredArrayIgnorePattern": "^_",
-            "ignoreRestSiblings": true,
-        }],
+        "@typescript-eslint/no-unused-vars": ["error", { "args": "none", "ignoreRestSiblings": true }],
         "@typescript-eslint/no-empty-function": ["off"],
 
         "@typescript-eslint/explicit-module-boundary-types": ["off"],

--- a/typescript.js
+++ b/typescript.js
@@ -13,7 +13,11 @@ module.exports = {
         // Allow the use of underscore to show args are not used.
         // This is helpful for seeing that a function implements
         // an interface but won't be using one of it's arguments.
-        "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
+        "@typescript-eslint/no-unused-vars": ["error", {
+            "args": "none",
+            "destructuredArrayIgnorePattern": "^_",
+            "ignoreRestSiblings": true,
+        }],
         "@typescript-eslint/no-empty-function": ["off"],
 
         "@typescript-eslint/explicit-module-boundary-types": ["off"],


### PR DESCRIPTION
Seems to be in line with what we're actually doing in our code, and would let us remove a lot of `eslint-disable-next-line` comments.