### PR TITLE
Codify multiline ternary formatting rules

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -53,7 +53,7 @@ module.exports = {
         "guard-for-in": ["off"],
         "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
         "block-spacing": ["off"],
-        "operator-linebreak": ["off"],
+        "operator-linebreak": ["error", "after", { overrides: { '?': 'before', ':': 'before' } }],
         // We don't mind strange alignments in EOL comments
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
 


### PR DESCRIPTION
Codifies this part of the style doc: https://github.com/vector-im/element-meta/pull/216/files#diff-97f46bd1ed0e6dfce7a7002e96f72ecd446b90c5eb5f48d687dc2d9df856290cR110

The non-ternary operator placement is codified too, with 'after' being the default for our js codebases.

This raises ~250 errors in react-sdk and ~140 in js-sdk, all of which can be `--fix`ed

```js
// error
const count = (direction == EventTimeline.BACKWARDS) ?
    tl.retreat(size) : tl.advance(size);

// -> ->
const count = (direction == EventTimeline.BACKWARDS)
    ? tl.retreat(size)
    : tl.advance(size);
```

```js
// error
let effectiveExpiresAt = this.channel.getTimestamp(event)
            + TIMEOUT_FROM_EVENT_TS;

// -> ->
let effectiveExpiresAt = this.channel.getTimestamp(event) +
            TIMEOUT_FROM_EVENT_TS;  
```
            