### PR TITLE
Deprecate enzyme; suggest testing-library instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ following depending on the configs you enable:
 * @typescript-eslint/parser
 * eslint
 * eslint-config-google
+* eslint-plugin-deprecate
 * eslint-plugin-jsx-a11y
 * eslint-plugin-react
 * eslint-plugin-react-hooks

--- a/react.js
+++ b/react.js
@@ -1,5 +1,6 @@
 module.exports = {
     plugins: [
+        "deprecate",
         "matrix-org",
         "react",
         "react-hooks",
@@ -52,5 +53,10 @@ module.exports = {
         "react-hooks/rules-of-hooks": ["error"],
         "react-hooks/exhaustive-deps": ["error"],
         "react/no-unknown-property": ["error"],
+
+        "deprecate/import": ["warn", {
+            name: "enzyme",
+            use: "@testing-library/react",
+        }],
     }
 }


### PR DESCRIPTION
PRs to be merged directly after this one:
- https://github.com/matrix-org/matrix-react-sdk/pull/9116
- https://github.com/vector-im/element-web/pull/22959