### PR TITLE
curly: all - no braceless blocks

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -17,7 +17,7 @@ module.exports = {
             code: 120,
             ignoreComments: true,
         }],
-        "curly": ["error", "multi-line"],
+        "curly": ["error", "all"],
         "prefer-const": ["error"],
         "comma-dangle": ["error", {
             arrays: "always-multiline",


### PR DESCRIPTION
Consider preferring consistent bracing of blocks instead of braceless single-line ifs. They can be easy to glance over, resulting in bugs.