### PR TITLE
Add prettier

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    printWidth: 120,
+    tabWidth: 4,
+    quoteProps: "consistent",
+    trailingComma: "all",
+};

--- a/README.md
+++ b/README.md
@@ -143,12 +143,14 @@ following depending on the configs you enable:
 * @typescript-eslint/parser
 * eslint
 * eslint-config-google
+* eslint-config-prettier
 * eslint-plugin-deprecate
 * eslint-plugin-jsx-a11y
 * eslint-plugin-react
 * eslint-plugin-react-hooks
 * eslint-plugin-import
 * eslint-plugin-unicorn
+* prettier
 * typescript
 
 ## Releasing

--- a/javascript.js
+++ b/javascript.js
@@ -3,20 +3,17 @@ module.exports = {
     extends: [
         "eslint:recommended",
         "google",
+        "prettier",
     ],
     rules: {
         // Additional rules we adhere to
-        "indent": [
-            "error",
-            4,
-            {
-                SwitchCase: 1,
-            },
-        ],
-        "max-len": ["error", {
-            code: 120,
-            ignoreComments: true,
-        }],
+        
+        // handled by prettier
+        "indent": "off",
+        "space-before-function-paren": "off",
+        "brace-style": "off",
+        "max-len": "off",
+
         "curly": ["error", "multi-line"],
         "prefer-const": ["error"],
         "comma-dangle": ["error", {
@@ -26,7 +23,6 @@ module.exports = {
             exports: "always-multiline",
             functions: "always-multiline",
         }],
-        "arrow-parens": ["off"],
         "arrow-spacing": ["error"],
         "space-in-parens": ["error"],
 
@@ -51,14 +47,12 @@ module.exports = {
         // Rules we do not want from the Google style guide
         "spaced-comment": ["off"],
         "guard-for-in": ["off"],
-        "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
         "block-spacing": ["off"],
         "operator-linebreak": ["off"],
         // We don't mind strange alignments in EOL comments
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
 
         "no-multiple-empty-lines": ["error", { "max": 1 }],
-        "object-curly-spacing": ["error", "always"],
 
         "import/order": [
             "error", {
@@ -68,5 +62,9 @@ module.exports = {
         ],
         "import/first": "error",
         "unicorn/no-instanceof-array": "error",
+
+        "quotes": ["error", "double", { avoidEscape: true }],
+        "object-curly-spacing": ["error", "always"],
+        "arrow-parens": ["error", "always"],
     },
 }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
         "@typescript-eslint/parser": "*",
         "eslint": "*",
         "eslint-config-google": "*",
+        "eslint-config-prettier": "*",
         "eslint-plugin-deprecate": "*",
         "eslint-plugin-import": "*",
         "eslint-plugin-jsx-a11y": "*",
         "eslint-plugin-react": "*",
         "eslint-plugin-react-hooks": "*",
         "eslint-plugin-unicorn": "*",
+        "prettier": "2.8.0",
         "typescript": "*"
     }
 }

--- a/react.js
+++ b/react.js
@@ -5,18 +5,17 @@ module.exports = {
         "react",
         "react-hooks",
     ],
+    extends: [
+        "prettier",
+    ],
     parserOptions: {
         ecmaFeatures: {
             jsx: true,
         },
     },
     rules: {
-        "max-len": ["error", {
-            // Ignore pure JSX lines
-            ignorePattern: '^\\s*<',
-            ignoreComments: true,
-            code: 120,
-        }],
+        // handled by prettier
+        "max-len": "off",
 
         // This just uses the React plugin to help ESLint known when
         // variables have been used in JSX
@@ -35,11 +34,7 @@ module.exports = {
             beforeClosing: "never",
         }],
 
-        "react/jsx-curly-spacing": ["error", {
-            allowMultiline: true,
-            children: { when: "always" },
-            attributes: { when: "never" },
-        }],
+        "react/jsx-curly-spacing": ["error", "never", { allowMultiline: true }],
 
         "react/jsx-curly-brace-presence": ["error", "never"],
 

--- a/typescript.js
+++ b/typescript.js
@@ -37,7 +37,7 @@ module.exports = {
                 "requireLast": true,
             },
             "singleline": {
-                "delimiter": "comma",
+                "delimiter": "semi",
                 "requireLast": false,
             },
         }],


### PR DESCRIPTION
This is going to be version 0.9

- Add prettier to the ESLint config
- Add a `.prettierrc.js` that can be used in other projects
- Disable / tweak conflicting ESLint rules

Related PRs:
- Ready: JS SDK https://github.com/matrix-org/matrix-js-sdk/pull/2906
- Needs update: Element Web https://github.com/vector-im/element-web/pull/23821