### PR TITLE
Allow any version of prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "eslint-plugin-react": "*",
         "eslint-plugin-react-hooks": "*",
         "eslint-plugin-unicorn": "*",
-        "prettier": "2.8.0",
+        "prettier": "*",
         "typescript": "*"
     }
 }


### PR DESCRIPTION
Currently prettier is specified as a peer dependency with a fixed version (2.8.0). It's the only peer dependency which is defined this way.

I think that the version of prettier used in each project should be managed by the project itself, especially now that prettier 3.0 is out.
