### PR TITLE
Enable consistent-type-imports typescript eslint rule

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -97,5 +97,8 @@ module.exports = {
 
         // Prevent invalid non-type re-exports of types, these can cause downstream build failures
         "@typescript-eslint/consistent-type-exports": ["error"],
+
+        // Prevent unnecessary runtime dependencies between files
+        "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
     },
 };


### PR DESCRIPTION
Some background on this rule: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/

Originally this was just for matrix-js-sdk: https://github.com/matrix-org/matrix-js-sdk/pull/4611#pullrequestreview-2542024134

Full docs on the rule: https://typescript-eslint.io/rules/consistent-type-imports

The `fixStyle` of `inline-type-imports` means that: where we are importing both types and implementations from a single `import` dep we keep one `import` line (as opposed to two) but with trade off of multiple `type` annotations.