### PR TITLE
Set upper bound on @stylistic/eslint-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@babel/core": "*",
         "@babel/eslint-parser": "*",
         "@babel/eslint-plugin": "*",
-        "@stylistic/eslint-plugin": "*",
+        "@stylistic/eslint-plugin": "<4",
         "@typescript-eslint/eslint-plugin": "*",
         "@typescript-eslint/parser": "*",
         "eslint": "<9",


### PR DESCRIPTION
v4+ supports only ESLint v9+, while this plugin still doesn't support past ESLint v8.  So, restrict it to be <v4.

See https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v4.0.0